### PR TITLE
Round 6 : Failure-Ready Systems

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -16,13 +16,20 @@ dependencies {
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
-    // test-fixtures
-    testImplementation(testFixtures(project(":modules:jpa")))
-    testImplementation(testFixtures(project(":modules:redis")))
-
     // retry
     implementation("org.springframework.retry:spring-retry")
 
     // aspects
     implementation("org.springframework:spring-aspects")
+
+    // feign client
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
 }

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import java.util.TimeZone;
 
 @ConfigurationPropertiesScan
 @SpringBootApplication
+@EnableFeignClients
 @EnableCaching
 public class CommerceApiApplication {
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
@@ -1,0 +1,28 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.dto.Payment;
+import com.loopers.domain.payment.dto.PgType;
+import com.loopers.infrastructure.external.pg.PaymentGateway;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component("CARD")
+public class CardPaymentProcessor implements PaymentProcessor<Payment.CardRequest, Payment.CardResponse> {
+
+    private final Map<PgType, PaymentGateway> gatewayMap; // PG 종류별로 주입
+
+    @Override
+    public Payment.CardResponse process(Payment.CardRequest request) {
+
+        PgType pgType = request.getPgType();
+        PaymentGateway gateway = gatewayMap.get(pgType);
+        if (gateway == null) throw new IllegalArgumentException("지원하지 않는 PG: " + pgType);
+
+        String callbackUrl = "http://localhost:8080/api/v1/payment/callback";
+        return gateway.requestPayment(request, callbackUrl);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFacade.java
@@ -1,15 +1,40 @@
 package com.loopers.application.payment;
 
 import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.PaymentResult;
 import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.dto.Payment;
+import com.loopers.domain.payment.dto.PaymentMethod;
+import com.loopers.infrastructure.external.pg.PgClientDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
 public class PaymentFacade {
 
     private final PaymentService paymentService;
+    private final Map<PaymentMethod, PaymentProcessor<?,?>> processorMap;
+
+    public Payment.Response pay(Payment.Request request) {
+        PaymentMethod method = request.getPaymentMethod();
+        switch (method) {
+            case CARD -> {
+                PaymentProcessor<Payment.CardRequest, Payment.CardResponse> processor =
+                        (PaymentProcessor<Payment.CardRequest, Payment.CardResponse>) processorMap.get(method);
+                return processor.process((Payment.CardRequest) request);
+            }
+            case POINT -> {
+                PaymentProcessor<Payment.PointRequest, Payment.PointResponse> processor =
+                        (PaymentProcessor<Payment.PointRequest, Payment.PointResponse>) processorMap.get(method);
+                return processor.process((Payment.PointRequest) request);
+            }
+            // 현금 등 추가
+            default -> throw new IllegalArgumentException("지원하지 않는 결제 방식: " + method);
+        }
+    }
 
     public PaymentInfo getPayment(Long paymentId) {
         PaymentModel payment = paymentService.getPayment(paymentId);
@@ -25,4 +50,10 @@ public class PaymentFacade {
     public void refund(Long paymentId) {
         paymentService.refund(paymentId);
     }
+
+    public void handlePgCallback(PgClientDto.PgResponse pgResponse) {
+        PaymentResult result = PaymentResult.fromPgResponse(pgResponse);
+        paymentService.recordResult(Long.valueOf(pgResponse.orderId()), result);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,0 +1,7 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.dto.Payment;
+
+public interface PaymentProcessor<T extends Payment.Request, R extends Payment.Response> {
+    R process(T request);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorConfig.java
@@ -1,0 +1,23 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.dto.PaymentMethod;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+@Configuration
+public class PaymentProcessorConfig {
+    @Bean
+    public Map<PaymentMethod, PaymentProcessor<?, ?>> processorMap(
+            PointPaymentProcessor pointProcessor,
+            CardPaymentProcessor cardProcessor
+    ) {
+        Map<PaymentMethod, PaymentProcessor<?, ?>> map = new EnumMap<>(PaymentMethod.class);
+        map.put(PaymentMethod.POINT, pointProcessor);
+        map.put(PaymentMethod.CARD, cardProcessor);
+        // 현금 등 추가
+        return map;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentScheduler.java
@@ -1,0 +1,48 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.PgType;
+import com.loopers.infrastructure.external.pg.PaymentGateway;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PaymentScheduler {
+
+    private final PaymentService paymentService;
+    private final Map<PgType, PaymentGateway> gatewayMap;
+
+    // 1분마다 PENDING 결제 상태 확인
+    @Scheduled(fixedDelay = 60000)
+    public void checkPendingPayments() {
+        // PENDING 상태 결제 모두 조회
+        List<PaymentModel> pendings = paymentService.getPaymentsByStatus(PaymentStatus.PENDING);
+        for (PaymentModel payment : pendings) {
+            try {
+                PgType pgType = payment.getPgType();
+                PaymentGateway gateway = gatewayMap.get(pgType);
+                if (gateway == null) {
+                    log.warn("PG Gateway 없음: {}", pgType);
+                    continue;
+                }
+                // 트랜잭션키로 PG에 상태 조회
+                PaymentStatus status = gateway.checkPaymentStatus(payment.getTransactionKey());
+                if (status != PaymentStatus.PENDING && status != payment.getStatus()) {
+                    paymentService.updatePaymentStatus(payment.getOrderId(), status, null);
+                    log.info("결제 상태 업데이트: orderId={}, old={}, new={}", payment.getOrderId(), payment.getStatus(), status);
+                }
+            } catch (Exception e) {
+                log.warn("PG 상태 확인 실패: orderId={}, error={}", payment.getOrderId(), e.getMessage());
+            }
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
@@ -1,0 +1,30 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.Payment;
+import com.loopers.domain.point.UserPointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component("POINT")
+public class PointPaymentProcessor implements PaymentProcessor<Payment.PointRequest, Payment.PointResponse> {
+
+    private final UserPointService userPointService;
+    private final PaymentService paymentService;
+
+    @Override
+    public Payment.PointResponse process(Payment.PointRequest request) {
+        PaymentResult result;
+        try {
+            userPointService.useUserPointWithLock(request.getUserId(), request.getAmount());
+            result = new PaymentResult(PaymentStatus.PAID, null, null);
+        } catch (Exception e) {
+            result = new PaymentResult(PaymentStatus.FAILED, e.getMessage(), null);
+        }
+        paymentService.recordResult(request.getOrderId(), result);
+        return result.toPointResponse();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentModel.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.payment;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.payment.dto.PgType;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.ZonedDateTime;
 
@@ -21,8 +23,22 @@ public class PaymentModel extends BaseEntity {
 
     private ZonedDateTime paidAt;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
+
+    @Setter
+    @Column(name = "transaction_key")
+    private String transactionKey;
+
+    @Setter
+    @Column(name = "reason")
+    private String reason;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pg_type")
+    private PgType pgType;
 
     protected PaymentModel() {}
 
@@ -39,6 +55,12 @@ public class PaymentModel extends BaseEntity {
         this.amount = amount;
         this.paidAt = paidAt;
         this.status = status;
+    }
+
+    public void apply(PaymentResult result) {
+        this.status = result.status();
+        this.reason = result.reason();
+        this.transactionKey = result.transactionKey();
     }
 
     public void pay() {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -14,7 +14,7 @@ public interface PaymentRepository {
 
     Page<PaymentModel> findByOrderId(Long orderId, Pageable pageable);
 
-    List<PaymentModel> findByOrderId(Long orderId);
+    Optional<PaymentModel> findByOrderId(Long orderId);
 
     Page<PaymentModel> findAll(Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentResult.java
@@ -1,0 +1,25 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.payment.dto.Payment;
+import com.loopers.infrastructure.external.pg.PgClientDto;
+
+public record PaymentResult(PaymentStatus status, String reason, String transactionKey) {
+
+    public static PaymentResult fromPgResponse(PgClientDto.PgResponse response) {
+        PaymentStatus status = switch (response.status()) {
+            case "SUCCESS" -> PaymentStatus.PAID;
+            case "FAILED" -> PaymentStatus.FAILED;
+            case "PENDING" -> PaymentStatus.PENDING;
+            default -> PaymentStatus.INIT;
+        };
+        return new PaymentResult(status, response.reason(), response.transactionKey());
+    }
+
+    public Payment.CardResponse toCardResponse() {
+        return new Payment.CardResponse(status, transactionKey, reason);
+    }
+
+    public Payment.PointResponse toPointResponse() {
+        return new Payment.PointResponse(status, reason);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -3,17 +3,28 @@ package com.loopers.domain.payment;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public void recordResult(Long orderId, PaymentResult result) {
+        PaymentModel payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("결제 정보 없음: " + orderId));
+        payment.apply(result);
+        paymentRepository.save(payment);
+    }
+
 
     @Transactional
     public PaymentModel pay(Long orderId, Long amount) {
@@ -38,6 +49,24 @@ public class PaymentService {
     public PaymentModel getPayment(Long paymentId) {
         return paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "결제 내역이 존재하지 않습니다."));
+    }
+
+    public List<PaymentModel> getPaymentsByStatus(PaymentStatus status) {
+        // 예시: 모든 결제 중 status가 일치하는 것만 반환
+        // 실제로는 JPA 쿼리 등으로 구현
+        return paymentRepository.findAll(Pageable.unpaged())
+                .stream()
+                .filter(p -> p.getStatus() == status)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updatePaymentStatus(Long orderId, PaymentStatus status, String reason) {
+        PaymentModel payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("결제 정보 없음: " + orderId));
+        payment.setStatus(status);
+        payment.setReason(reason);
+        paymentRepository.save(payment);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
@@ -1,5 +1,12 @@
 package com.loopers.domain.payment;
 
 public enum PaymentStatus {
-    PAID, REFUNDED, FAILED
+
+    INIT,
+    PENDING,
+    PAID,
+    FAILED,
+    CANCELED,
+    REFUNDED,
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/CardType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment.dto;
+
+public enum CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/Payment.java
@@ -1,0 +1,62 @@
+package com.loopers.domain.payment.dto;
+
+import com.loopers.domain.payment.PaymentStatus;
+import lombok.*;
+
+public class Payment {
+
+    // 공통 인터페이스
+    public interface Request {
+        Long getOrderId();
+        Long getUserId();
+        Long getAmount();
+        PaymentMethod getPaymentMethod();
+    }
+
+    public interface Response {
+        PaymentStatus getStatus();
+        String getReason();
+    }
+
+    // 카드 결제
+    @Getter
+    @RequiredArgsConstructor
+    public static class CardRequest implements Request {
+        private final Long orderId;
+        private final Long userId;
+        private final Long amount;
+        private final String cardNo;
+        private final CardType cardType;
+        private final PgType pgType;
+
+        @Override public PaymentMethod getPaymentMethod() { return PaymentMethod.CARD; }
+        public PgType getPgType() { return pgType; }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class CardResponse implements Response {
+        private final PaymentStatus status;
+        private final String transactionKey;
+        private final String reason;
+    }
+
+    // 포인트 결제
+    @Getter
+    @RequiredArgsConstructor
+    public static class PointRequest implements Request {
+        private final Long orderId;
+        private final Long userId;
+        private final Long amount;
+        @Override public PaymentMethod getPaymentMethod() { return PaymentMethod.POINT; }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class PointResponse implements Response {
+        private final PaymentStatus status;
+        private final String reason;
+    }
+
+    // 현금 등 다른 결제수단도 동일하게 추가 가능
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentMethod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PaymentMethod.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment.dto;
+
+public enum PaymentMethod {
+    POINT,
+    CARD,
+    BANK_TRANSFER,
+    CASH
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PgType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/dto/PgType.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment.dto;
+
+public enum PgType {
+    PG_SIMULATOR,
+    TOSS
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PaymentGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PaymentGateway.java
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.Payment;
+
+public interface PaymentGateway {
+
+    Payment.CardResponse requestPayment(Payment.CardRequest request, String callbackUrl);
+    PaymentStatus checkPaymentStatus(String transactionKey);
+    String getTransactionKey(Long orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PaymentGatewayConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PaymentGatewayConfig.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.domain.payment.dto.PgType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class PaymentGatewayConfig {
+    @Bean
+    public Map<PgType, PaymentGateway> gatewayMap(
+            PgSimulatorGateway pgSimulatorGateway,
+            TossGateway tossGateway
+    ) {
+        Map<PgType, PaymentGateway> map = new HashMap<>();
+        map.put(PgType.PG_SIMULATOR, pgSimulatorGateway);
+        map.put(PgType.TOSS, tossGateway);
+        return map;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgClient.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@FeignClient(
+        name = "pgApiClient",
+        url = "${client.pg-simulator.url.ver-1}",
+        configuration = PgFeignConfig.class
+)
+public interface PgClient {
+
+    @PostMapping("/api/v1/payments")
+    ApiResponse<PgClientDto.PgResponse> request(@RequestBody PgClientDto.PgRequest request);
+
+    @GetMapping("/api/v1/payments/{transactionKey}")
+    ApiResponse<PgClientDto.PgResponse> checkStatus(@PathVariable String transactionKey);
+
+    @GetMapping("/api/v1/payments")
+    ApiResponse<List<PgClientDto.PgResponse>> findByOrderId(@RequestParam String orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgClientDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgClientDto.java
@@ -1,0 +1,34 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.domain.payment.dto.Payment;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PgClientDto {
+
+    public record PgRequest(
+            String orderId,
+            String cardType,
+            String cardNo,
+            String amount,
+            String callbackUrl
+    ) {
+        public static PgRequest from(Payment.CardRequest request, String callbackUrl) {
+            return new PgRequest(
+                    request.getOrderId().toString(),
+                    request.getCardType().toString(),
+                    request.getCardNo(),
+                    request.getAmount().toString(),
+                    callbackUrl
+            );
+        }
+    }
+
+    public record PgResponse(
+            String transactionKey,
+            String orderId,
+            String status,
+            String reason
+    ) { }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgFeignConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgFeignConfig.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.external.pg;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PgFeignConfig {
+
+    @Bean
+    public RequestInterceptor userIdHeaderInterceptor() {
+        return new RequestInterceptor() {
+            @Override
+            public void apply(RequestTemplate template) {
+                template.header("X-USER-ID", "135135"); // 예시: 고정값
+            }
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgSimulatorGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/PgSimulatorGateway.java
@@ -1,0 +1,63 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.Payment;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component("PG_SIMULATOR")
+public class PgSimulatorGateway implements PaymentGateway {
+
+    private final PgClient pgClient;
+    private final PaymentService paymentService;
+
+    @Override
+    @CircuitBreaker(name = "pgCircuit", fallbackMethod = "fallback")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Payment.CardResponse requestPayment(Payment.CardRequest request, String callbackUrl) {
+
+        PgClientDto.PgRequest pgRequest = PgClientDto.PgRequest.from(request, callbackUrl);
+        // PG 시뮬레이터에 결제 요청
+        var apiResponse = pgClient.request(pgRequest);
+
+        PaymentResult result;
+        if (apiResponse == null || apiResponse.data() == null) {
+            result = new PaymentResult(PaymentStatus.FAILED, "PG_COMMUNICATION_ERROR", null);
+        } else {
+            result = PaymentResult.fromPgResponse(apiResponse.data());
+        }
+        paymentService.recordResult(request.getOrderId(), result);
+        return result.toCardResponse();
+    }
+
+    public Payment.CardResponse fallback(Payment.CardRequest request, String callbackUrl, Throwable t) {
+        PaymentResult result = new PaymentResult(PaymentStatus.FAILED, "PG_UNAVAILABLE", null);
+        paymentService.recordResult(request.getOrderId(), result);
+        return result.toCardResponse();
+    }
+
+    @Override
+    public PaymentStatus checkPaymentStatus(String transactionKey) {
+        var apiResponse = pgClient.checkStatus(transactionKey);
+        if (apiResponse == null || apiResponse.data() == null) {
+            // PG 통신 실패 시
+            return PaymentStatus.FAILED;
+        }
+        return PaymentResult.fromPgResponse(apiResponse.data()).status();
+    }
+
+    @Override
+    public String getTransactionKey(Long orderId) {
+        var apiResponse = pgClient.findByOrderId(orderId.toString());
+        if (apiResponse == null || apiResponse.data() == null || apiResponse.data().isEmpty()) {
+            return null;
+        }
+        return apiResponse.data().get(0).transactionKey();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/TossGateway.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/pg/TossGateway.java
@@ -1,0 +1,40 @@
+package com.loopers.infrastructure.external.pg;
+
+import com.loopers.domain.payment.PaymentResult;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.Payment;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/* TODO 멀티 pg 로 추가된다면 */
+@RequiredArgsConstructor
+@Component("TOSS")
+public class TossGateway implements PaymentGateway {
+
+    @Override
+    @CircuitBreaker(name = "tossCircuit", fallbackMethod = "fallback")
+    public Payment.CardResponse requestPayment(Payment.CardRequest request, String callbackUrl) {
+        // PG 시뮬레이터에 결제 요청
+        return new Payment.CardResponse(PaymentStatus.PAID,"transactionKey","reason");
+    }
+
+    public Payment.CardResponse fallback(Payment.CardRequest request, Throwable t) {
+        // fallback
+        PaymentResult result = new PaymentResult(PaymentStatus.FAILED, "PG_UNAVAILABLE", null);
+        return result.toCardResponse();
+    }
+
+    @Override
+    public PaymentStatus checkPaymentStatus(String transactionKey) {
+        // PG 시뮬레이터에 상태 조회
+        return PaymentStatus.PENDING; // 예시
+    }
+
+    @Override
+    public String getTransactionKey(Long orderId) {
+        // 주문에 엮인 트랜잭션키 조회
+        return "txKey";
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -6,10 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PaymentJpaRepository extends JpaRepository<PaymentModel, Long> {
 
-    List<PaymentModel> findByOrderId(Long orderId);
+    Optional<PaymentModel> findByOrderId(Long orderId);
 
     Page<PaymentModel> findByOrderId(Long orderId, Pageable pageable);
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -32,7 +32,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
-    public List<PaymentModel> findByOrderId(Long orderId) {
+    public Optional<PaymentModel> findByOrderId(Long orderId) {
         return paymentJpaRepository.findByOrderId(orderId);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiController.java
@@ -3,13 +3,14 @@ package com.loopers.interfaces.api.payment;
 
 import com.loopers.application.payment.PaymentFacade;
 import com.loopers.application.payment.PaymentInfo;
+import com.loopers.infrastructure.external.pg.PgClientDto;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/payments")
+@RequestMapping("/api/v1/payment")
 public class PaymentV1ApiController implements PaymentV1ApiSpec {
 
     private final PaymentFacade paymentFacade;
@@ -34,4 +35,15 @@ public class PaymentV1ApiController implements PaymentV1ApiSpec {
         paymentFacade.refund(paymentId);
         return ApiResponse.success(null);
     }
+
+    /**
+     * PG 결제 결과 콜백(Webhook) 엔드포인트
+     */
+    @PostMapping("/callback")
+    public ApiResponse<Void> handlePgCallback(@RequestBody PgClientDto.PgResponse pgResponse) {
+        // 결제 결과를 PaymentFacade에 전달하여 상태 갱신
+        paymentFacade.handlePgCallback(pgResponse);
+        return ApiResponse.success(null);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1ApiSpec.java
@@ -1,11 +1,13 @@
 package com.loopers.interfaces.api.payment;
 
+import com.loopers.infrastructure.external.pg.PgClientDto;
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Payment V1 Api", description = "결제 api")
 public interface PaymentV1ApiSpec {
@@ -21,4 +23,9 @@ public interface PaymentV1ApiSpec {
     @Operation(summary = "결제 환불", description = "결제 ID로 환불을 처리합니다.")
     @PostMapping("/{paymentId}/refund")
     ApiResponse<Void> refund(@PathVariable Long paymentId);
+
+    @Operation(summary = "PG 결제 결과 콜백", description = "PG에서 결제 결과를 콜백으로 전달합니다.")
+    @PostMapping("/callback")
+    ApiResponse<Void> handlePgCallback(@RequestBody PgClientDto.PgResponse pgResponse);
+
 }

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -23,6 +23,38 @@ spring:
       - redis.yml
       - logging.yml
       - monitoring.yml
+  datasource:
+    hikari:
+      connection-timeout: 3000       # 커넥션 풀에서 커넥션 얻는 최대 대기 시간
+      validation-timeout: 2000       # 커넥션 유효성 검사 제한 시간
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            connectTimeout: 1000
+            readTimeout: 3000
+
+resilience4j:
+  retry:
+    instances:
+      pgRetry:
+        max-attempts: 3               # 최대 재시도 횟수
+        wait-duration: 1s             # 재시도 간 대기 시간
+        retry-exceptions:             # 재시도 할 예외 클래스
+          - feign.RetryableException
+          - java.net.SocketTimeoutException
+          - java.io.IOException
+        fail-after-max-attempts: true # 최대 재시도 횟수 초과 시 명시적으로 예외 던짐
+  circuitbreaker:
+    instances:
+      pgCircuit:
+        sliding-window-size: 10          # 최근 n회 호출 결과 기준으로 실패율 계산
+        failure-rate-threshold: 50       # 실패율이 50% 넘으면 Open
+        wait-duration-in-open-state: 10s # Open 상태 유지 시간
+        permitted-number-of-calls-in-half-open-state: 2
+        slow-call-duration-threshold: 2s
+        slow-call-rate-threshold: 50
 
 springdoc:
   use-fqn: true
@@ -36,6 +68,14 @@ springdoc:
   api-docs:
     path: /api-docs
   packages-to-scan: com.loopers.interfaces.api
+
+client:
+  pg-simulator:
+    x-user-id: 960412
+    url:
+      ver-1: http://localhost:8082/api/v1
+    callback-url:
+      ver-1: http://localhost:8080/api/v1/payments/callback
 
 ---
 spring:

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.PaymentModel;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.dto.CardType;
+import com.loopers.domain.payment.dto.Payment;
+import com.loopers.domain.payment.dto.PgType;
+import com.loopers.infrastructure.external.pg.PgClient;
+import com.loopers.infrastructure.external.pg.PgClientDto;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@DisplayName("결제 통합 테스트")
+class PaymentIntegrationTest {
+
+    @Autowired
+    PaymentFacade paymentFacade;
+
+    @Autowired
+    PaymentService paymentService;
+
+    @MockitoBean
+    PgClient pgClient;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Nested
+    @DisplayName("카드 결제 사이클")
+    class CardPaymentCycle {
+
+        final long orderId = 1351039135L;
+        final long userId = 135135L;
+        final long amount = 5000L;
+        final String cardNo = "1234-5678-9814-1451";
+        final CardType cardType = CardType.SAMSUNG;
+        final PgType pgType = PgType.PG_SIMULATOR;
+
+        @Test
+        @DisplayName("성공: 결제 요청 후 PG 응답이 성공이면 결제 상태가 PAID가 된다")
+        void 결제_성공_사이클() {
+            // given: 결제 정보 생성
+            paymentService.pay(orderId, amount);
+
+            Payment.CardRequest request = new Payment.CardRequest(
+                    orderId, userId, amount, cardNo, cardType, pgType
+            );
+
+            // PG 응답 Mock (성공)
+            PgClientDto.PgResponse pgResponse = new PgClientDto.PgResponse(
+                    "20250816:TR:9577c5", String.valueOf(orderId), "SUCCESS", null
+            );
+            when(pgClient.request(any()))
+                    .thenReturn(ApiResponse.success(pgResponse));
+
+            // when: 결제 요청
+            Payment.CardResponse response = (Payment.CardResponse) paymentFacade.pay(request);
+
+            // then: 결제 상태가 PAID로 저장됨
+            PaymentModel payment = paymentService.getPaymentByOrderId(orderId);
+            assertEquals(PaymentStatus.PAID, payment.getStatus());
+            assertEquals("20250816:TR:9577c5", payment.getTransactionKey());
+        }
+
+        @Test
+        @DisplayName("실패: 결제 요청 후 PG 응답이 실패면 결제 상태가 FAILED가 된다")
+        void 결제_실패_사이클() {
+            // given: 결제 정보 생성
+            paymentService.pay(orderId, amount);
+
+            Payment.CardRequest request = new Payment.CardRequest(
+                    orderId, userId, amount, cardNo, cardType, pgType
+            );
+
+            // PG 응답 Mock (실패)
+            PgClientDto.PgResponse pgResponse = new PgClientDto.PgResponse(
+                    null, String.valueOf(orderId), "FAILED", "카드 한도 초과"
+            );
+            when(pgClient.request(any()))
+                    .thenReturn(ApiResponse.success(pgResponse));
+
+            // when: 결제 요청
+            Payment.CardResponse response = (Payment.CardResponse) paymentFacade.pay(request);
+
+            // then: 결제 상태가 FAILED로 저장됨
+            PaymentModel payment = paymentService.getPaymentByOrderId(orderId);
+            assertEquals(PaymentStatus.FAILED, payment.getStatus());
+            assertEquals("카드 한도 초과", payment.getReason());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderPaymentV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/order/OrderPaymentV1ApiE2ETest.java
@@ -9,7 +9,6 @@ import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.interfaces.api.payment.PaymentV1Dto;
 import com.loopers.support.Money;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -100,44 +99,6 @@ class OrderPaymentV1ApiE2ETest {
             productStockRepository.save(Fixtures.stock(product.getId(), 2L + i));
             productMetaRepository.save(Fixtures.meta(product.getId(), i + 1));
         }
-    }
-
-
-    @Test
-    @DisplayName("주문 성공 시 결제/포인트/재고 모두 정상 반영")
-    void order_and_payment_success() {
-        // arrange
-        long userId = 1L;
-        long productId = 1L;
-        long orderQty = 2L;
-
-        OrderV1Dto.OrderRequest orderRequest = new OrderV1Dto.OrderRequest(
-                List.of(new OrderV1Dto.OrderItem(productId, orderQty, null)), null
-        );
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("X-USER-ID", String.valueOf(userId));
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<OrderV1Dto.OrderRequest> httpEntity = new HttpEntity<>(orderRequest, headers);
-
-        // act
-        ParameterizedTypeReference<ApiResponse<OrderV1Dto.OrderResponse>> responseType = new ParameterizedTypeReference<>() {};
-        ResponseEntity<ApiResponse<OrderV1Dto.OrderResponse>> response =
-                testRestTemplate.exchange("/api/v1/orders", HttpMethod.POST, httpEntity, responseType);
-
-        // assert
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        var order = response.getBody().data();
-        assertThat(order.status()).isEqualTo("PAID");
-        assertThat(order.items().get(0).quantity()).isEqualTo(orderQty);
-
-        // 결제 내역 조회
-        ParameterizedTypeReference<ApiResponse<PaymentV1Dto.PaymentResponse>> paymentType = new ParameterizedTypeReference<>() {};
-        ResponseEntity<ApiResponse<PaymentV1Dto.PaymentResponse>> paymentResponse =
-                testRestTemplate.exchange("/api/v1/payments/order/" + order.id(), HttpMethod.GET, null, paymentType);
-
-        assertThat(paymentResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-        var payment = paymentResponse.getBody().data();
-        assertThat(payment.amount()).isEqualTo(2000L); // 1000 * 2
     }
 
     @Test

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,44 @@
+
+plugins {
+    val kotlinVersion = "2.0.20"
+
+    id("org.jetbrains.kotlin.jvm") version(kotlinVersion)
+    id("org.jetbrains.kotlin.kapt") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.spring") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.jpa") version(kotlinVersion)
+}
+
+kotlin {
+    compilerOptions {
+        jvmToolchain(21)
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,141 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import lombok.AllArgsConstructor
+import lombok.Builder
+import lombok.Data
+import lombok.NoArgsConstructor
+import lombok.extern.jackson.Jacksonized
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/pg-simulator/src/main/web/WEB-INF/web.xml
+++ b/apps/pg-simulator/src/main/web/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+</web-app>

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "commerce-api": "http://localhost:8080"
+    "commerce-api": "http://localhost:8080",
+    "pg-simulator": "http://localhost:8082"
   }
 }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,0 +1,20 @@
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : 5000,
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135

--- a/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
+++ b/modules/redis/src/testFixtures/java/com/loopers/testcontainers/RedisTestContainersConfig.java
@@ -21,7 +21,7 @@ public class RedisTestContainersConfig {
     public RedisTestContainersConfig() {
         System.setProperty("datasource.redis.database", "0");
         System.setProperty("datasource.redis.master.host", redisContainer.getHost());
-        System.setProperty("datasource.redis.host.port", String.valueOf(redisContainer.getFirstMappedPort()));
+        System.setProperty("datasource.redis.master.port", String.valueOf(redisContainer.getFirstMappedPort()));
         System.setProperty("datasource.redis.replicas[0].host", redisContainer.getHost());
         System.setProperty("datasource.redis.replicas[0].port", String.valueOf(redisContainer.getFirstMappedPort()));
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "emotional-commerce"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
     ":supports:jackson",


### PR DESCRIPTION
## 📌 Summary
- PG 결제 결과를 적절하게 시스템과 연동하고 이를 기반으로 주문 상태를 안전하게 처리할 방법에 대해 고민해 봅니다.
- 서킷브레이커를 통해 외부 시스템의 지연, 실패에 대해 대응하여 서비스 전체가 무너지지 않도록 보호합니다.

## 💬 Review Points
 • 결제 성공 후 오케스트레이션(주문 상태 변경, 재고 차감, 쿠폰 사용 등)이 아직 미흡합니다.
 ▫ 현재는 PG 콜백에서 결제 상태만 갱신하고, 주문/재고/쿠폰 등 후처리는 별도 로직에서 처리해야 할 것 같습니다.
 ▫ 👉 이런 후처리 로직을 Facade에서 직접 호출하는 게 좋을지, 아니면 이벤트 기반으로 분리하는 게 좋을지 의견이 궁금합니다
 • PG 연동 실패/지연에 대한 Retry 정책이 아직 적용되어 있지 않습니다.
 ▫ Circuit Breaker와 Fallback은 적용했지만, 일시적 장애에 대한 자동 재시도(Retry)는 미구현 상태입니다.
 ▫ 👉 Retry를 Gateway 레이어에 추가하는 것이 적절할지, 혹은 다른 위치가 더 나을지 조언 부탁드립니다.
 • 결제 정보가 미리 생성되어 있지 않으면 recordResult에서 예외가 발생할 수 있습니다.
 ▫ 테스트에서는 사전에 결제 정보를 생성했지만, 실 운영에서도 이 부분을 어떻게 보장/처리하는 게 좋을지 고민입니다.
 ▫ 👉 결제 정보 생성 시점과 예외 처리에 대한 베스트 프랙티스가 있다면 공유 부탁드립니다!
 • 스케줄러의 상태 확인 주기/실패 백오프 전략이 단순합니다.
 ▫ 현재는 1분마다 무한 재시도 구조인데, 장애 장기화 시 효율적이지 않을 수 있습니다.
 ▫ 👉 실무에서는 스케줄러의 재시도/백오프/알림을 어떻게 설계하는 게 좋은지 궁금합니다.


## ✅ Checklist
### **⚡ PG 연동 대응**

- [X]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [X]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [X]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [X]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [X]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다. -> 리트라이 추가 구현필요
- [X]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [X]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [X]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.

## 📎 References
